### PR TITLE
Flutter - iOS - ImagePicker support below iOS 14 version

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -27,6 +27,8 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 
 flutter_ios_podfile_setup
 
+pod 'GMImagePicker', '~> 0.0.2'
+
 target 'Runner' do
   use_frameworks!
   use_modular_headers!

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,5 +1,6 @@
 PODS:
   - Flutter (1.0.0)
+  - GMImagePicker (0.0.2)
   - image_picker (0.0.1):
     - Flutter
   - path_provider_ios (0.0.1):
@@ -15,6 +16,7 @@ PODS:
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
+  - GMImagePicker (~> 0.0.2)
   - image_picker (from `.symlinks/plugins/image_picker/ios`)
   - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
   - permission_handler (from `.symlinks/plugins/permission_handler/ios`)
@@ -23,6 +25,7 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
+    - GMImagePicker
     - ScanbotSDK
 
 EXTERNAL SOURCES:
@@ -41,6 +44,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  GMImagePicker: 6438a6764d6280b1dbf19b59140313f5a73daeeb
   image_picker: 9aa50e1d8cdacdbed739e925b7eea16d014367e6
   path_provider_ios: 7d7ce634493af4477d156294792024ec3485acd5
   permission_handler: ccb20a9fad0ee9b1314a52b70b76b473c5f8dab0
@@ -48,6 +52,6 @@ SPEC CHECKSUMS:
   ScanbotSDK: 1ff91a1758c53664f88e5c22d78b88dfeaf2f4eb
   shared_preferences: af6bfa751691cdc24be3045c43ec037377ada40d
 
-PODFILE CHECKSUM: 7368163408c647b7eb699d0d788ba6718e18fb8d
+PODFILE CHECKSUM: 6a1f2e6d09433e45c1778cf1a8d64cc990284cc1
 
 COCOAPODS: 1.11.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -8,14 +8,15 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
-		361C2DA70A9BE4811B07353B /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 844140EC25CE5BA71F76B4FC /* Pods_Runner.framework */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		55BBB71A27BD287700CFEC33 /* GMImagePickerHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BBB71927BD287700CFEC33 /* GMImagePickerHelper.swift */; };
 		64AAD6EF23731ACF0035F4B4 /* ScanbotSDKOCRData.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 64AAD6EE23731ACF0035F4B4 /* ScanbotSDKOCRData.bundle */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		9740EEB41CF90195004384FC /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 9740EEB21CF90195004384FC /* Debug.xcconfig */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		F4CCF9C8309EA2C105E52985 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 844140EC25CE5BA71F76B4FC /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -36,6 +37,7 @@
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		55BBB71927BD287700CFEC33 /* GMImagePickerHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GMImagePickerHelper.swift; sourceTree = "<group>"; };
 		64AAD6EE23731ACF0035F4B4 /* ScanbotSDKOCRData.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = ScanbotSDKOCRData.bundle; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -57,7 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				361C2DA70A9BE4811B07353B /* Pods_Runner.framework in Frameworks */,
+				F4CCF9C8309EA2C105E52985 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -106,6 +108,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				55BBB71927BD287700CFEC33 /* GMImagePickerHelper.swift */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -256,6 +259,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/GMImagePicker/GMImagePicker.framework",
 				"${BUILT_PRODUCTS_DIR}/image_picker/image_picker.framework",
 				"${BUILT_PRODUCTS_DIR}/path_provider_ios/path_provider_ios.framework",
 				"${BUILT_PRODUCTS_DIR}/scanbot_sdk/scanbot_sdk.framework",
@@ -264,6 +268,7 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GMImagePicker.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/image_picker.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider_ios.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/scanbot_sdk.framework",
@@ -314,6 +319,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				55BBB71A27BD287700CFEC33 /* GMImagePickerHelper.swift in Sources */,
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 			);

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,13 +1,15 @@
 import UIKit
 import Flutter
+import GMImagePicker
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
-  override func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-  ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
-  }
+    override func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        _ = GMImagePickerHelper()
+        GeneratedPluginRegistrant.register(with: self)
+        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
 }

--- a/ios/Runner/GMImagePickerHelper.swift
+++ b/ios/Runner/GMImagePickerHelper.swift
@@ -78,6 +78,8 @@ class GMImagePickerHelper : NSObject, GMImagePickerControllerDelegate {
         picker.displaySelectionInfoToolbar = true
         picker.displayAlbumsNumberOfAssets = true
         picker.modalPresentationStyle = .fullScreen
+        // below line is added to avoid/fix a library specific crash
+        picker.navigationController?.toolbar?.addSubview(UIView())
         
         if let viewController = (UIApplication.shared.delegate as? AppDelegate)?.window?.rootViewController {
             viewController.present(picker, animated: true, completion: nil)

--- a/ios/Runner/GMImagePickerHelper.swift
+++ b/ios/Runner/GMImagePickerHelper.swift
@@ -1,0 +1,127 @@
+//
+//  GMImagePickerHelper.swift
+//  Runner
+//
+//  Created by Mayank Patil on 11/02/22.
+//  Copyright © 2022 The Chromium Authors. All rights reserved.
+//
+import Foundation
+import UIKit
+import GMImagePicker
+import Flutter
+import AVFoundation
+/**
+ - GMImagePicker Helper class
+ Helps in picking image for the older versions of iOS
+ */
+class GMImagePickerHelper : NSObject, GMImagePickerControllerDelegate {
+    
+    let IMAGE_PICKER_CHANNEL_NAME = "imagePicker_old_version_ios"
+    var result : FlutterResult?
+    public override init() {
+        super.init()
+        self.initGMImagePickerHelper()
+    }
+    
+    /** Finish selecting photos from Photos App */
+    public func assetsPickerController(_ picker: GMImagePickerController!, didFinishPickingAssets assets: [Any]!) {
+        print("photos selected")
+        // background thread
+        DispatchQueue.global(qos: .background).async {
+            if assets is [PHAsset] {
+                let paths = self.getAbsoluteUrl(assets: assets as! [PHAsset])
+                DispatchQueue.main.async {
+                    // main thread
+                    let resultData : [String:Any] = ["uris":paths]
+                    self.result?(resultData.jsonString)
+                    picker.dismiss(animated: true, completion: nil)
+                }
+            }
+        }
+    }
+    
+    /** Photos app cancelled */
+    func assetsPickerControllerDidCancel(_ picker: GMImagePickerController!) {
+        self.result?([])
+        picker.dismiss(animated: true, completion: nil)
+    }
+    
+    /** Init the image picker helper class */
+    func initGMImagePickerHelper() {
+        let appDelegate = UIApplication.shared.delegate as? AppDelegate
+        if let controller = appDelegate?.window?.rootViewController as? FlutterViewController {
+            
+            let imagePickerChannel = FlutterMethodChannel(name: IMAGE_PICKER_CHANNEL_NAME,binaryMessenger: controller.binaryMessenger);
+            imagePickerChannel.setMethodCallHandler({
+                (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
+                DispatchQueue.main.async {
+                    
+                    print("This method is called")
+                    if call.method == "pickImagesFromPhotosApp" {
+                        self.result = result
+                        self.pickImagesFromPhotosApp()
+                    } else if call.method == "versionLessThanIOSFourteen"{
+                        result(self.versionLessThanIOSFourteen())
+                    }
+                }
+            })
+        }
+    }
+    
+    /** Opens the pickerViewController to show Photos App View */
+    private func pickImagesFromPhotosApp() {
+        
+        let picker = GMImagePickerController()
+        picker.delegate = self
+        picker.title = "Select"
+        picker.allowsMultipleSelection = true
+        picker.displaySelectionInfoToolbar = true
+        picker.displayAlbumsNumberOfAssets = true
+        picker.modalPresentationStyle = .fullScreen
+        
+        if let viewController = (UIApplication.shared.delegate as? AppDelegate)?.window?.rootViewController {
+            viewController.present(picker, animated: true, completion: nil)
+        }
+    }
+    
+    /** Get the absolute url from the image path */
+    func getAbsoluteUrl(assets: [PHAsset]) -> [String] {
+        var paths: [String] = []
+        
+        let group = DispatchGroup()
+        var path = ""
+        for asset in assets {
+            group.enter()
+            asset.requestContentEditingInput(with: PHContentEditingInputRequestOptions(), completionHandler: {(data,args) in
+                path = data?.fullSizeImageURL?.path ?? ""
+                group.leave()
+            })
+            group.wait()
+            paths.append(path)
+        }
+        return paths
+    }
+    
+    /**
+     Is version less than iOS 14
+     */
+    func versionLessThanIOSFourteen() -> String {
+        if #available(iOS 14, *) {
+            return "false"
+        } else {
+            return "true"
+        }
+    }
+}
+
+/** Extension added for json conversion*/
+extension Dictionary {
+    
+    var jsonString: String? {
+        if let json = try? JSONSerialization.data(withJSONObject: self) {
+            let convertedString = String(data: json, encoding: String.Encoding.utf8)
+            return convertedString
+        }
+        return nil
+    }
+}

--- a/ios/Runner/GMImagePickerHelper.swift
+++ b/ios/Runner/GMImagePickerHelper.swift
@@ -25,7 +25,6 @@ class GMImagePickerHelper : NSObject, GMImagePickerControllerDelegate {
     
     /** Finish selecting photos from Photos App */
     public func assetsPickerController(_ picker: GMImagePickerController!, didFinishPickingAssets assets: [Any]!) {
-        print("photos selected")
         // background thread
         DispatchQueue.global(qos: .background).async {
             if assets is [PHAsset] {
@@ -55,8 +54,6 @@ class GMImagePickerHelper : NSObject, GMImagePickerControllerDelegate {
             imagePickerChannel.setMethodCallHandler({
                 (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
                 DispatchQueue.main.async {
-                    
-                    print("This method is called")
                     if call.method == "pickImagesFromPhotosApp" {
                         self.result = result
                         self.pickImagesFromPhotosApp()

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -23,9 +23,11 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string> </string>
+	<string>Camera Permission</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string></string>
+	<string>Photo Permission</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Photo Permission</string>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -495,7 +495,6 @@ class _MainPageWidgetState extends State<MainPageWidget> {
     var uris = List<Uri>.empty(growable: true);
     if (Platform.isIOS && await PlatformHelper.versionLessThanIOSFourteen()) {
       var result = await PlatformHelper.pickPhotosAsync();
-      print("The main method is executed");
       if (result?.uris?.isNotEmpty ?? false) {
         for (var path in result?.uris ?? List<String>.empty(growable: false)) {
           uris.add(Uri.file(path));

--- a/lib/model/model_data.dart
+++ b/lib/model/model_data.dart
@@ -1,0 +1,18 @@
+
+
+
+class ImagePickerResponse {
+  List<String>? uris;
+
+  ImagePickerResponse({this.uris});
+
+  ImagePickerResponse.fromJson(Map<String, dynamic> json) {
+    uris = json['uris'].cast<String>();
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = new Map<String, dynamic>();
+    data['uris'] = this.uris;
+    return data;
+  }
+}

--- a/lib/utility/platform_helper.dart
+++ b/lib/utility/platform_helper.dart
@@ -1,7 +1,6 @@
 
 
 import 'dart:convert';
-import 'dart:html';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:scanbot_sdk_example_flutter/model/model_data.dart';

--- a/lib/utility/platform_helper.dart
+++ b/lib/utility/platform_helper.dart
@@ -14,7 +14,6 @@ class PlatformHelper {
       var result = await _imagePickerOldVersionChannel.invokeMethod(
           'pickImagesFromPhotosApp');
       var resultData = ImagePickerResponse.fromJson(jsonDecode(result));
-      print("Result is:");
       return resultData;
     } catch (e) {
       return null;
@@ -30,7 +29,6 @@ class PlatformHelper {
     try {
       var result = await _imagePickerOldVersionChannel.invokeMethod(
           'versionLessThanIOSFourteen');
-      print(result.toString());
       if (result.toString() == "true") {
         isVersionLess = true;
       }

--- a/lib/utility/platform_helper.dart
+++ b/lib/utility/platform_helper.dart
@@ -1,0 +1,43 @@
+
+
+import 'dart:convert';
+import 'dart:html';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/services.dart';
+import 'package:scanbot_sdk_example_flutter/model/model_data.dart';
+
+class PlatformHelper {
+  static const _imagePickerOldVersionChannel = MethodChannel(
+      'imagePicker_old_version_ios');
+
+  static Future<ImagePickerResponse?> pickPhotosAsync() async {
+    try {
+      var result = await _imagePickerOldVersionChannel.invokeMethod(
+          'pickImagesFromPhotosApp');
+      var resultData = ImagePickerResponse.fromJson(jsonDecode(result));
+      print("Result is:");
+      return resultData;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /// if version is less than iOS 14
+  /// for Android return false always
+  /// true: version is less than 14
+  /// false: version is 14 or above
+  static Future<bool> versionLessThanIOSFourteen() async {
+    var isVersionLess = false;
+    try {
+      var result = await _imagePickerOldVersionChannel.invokeMethod(
+          'versionLessThanIOSFourteen');
+      print(result.toString());
+      if (result.toString() == "true") {
+        isVersionLess = true;
+      }
+    } catch (e) {
+      isVersionLess = false;
+    }
+    return isVersionLess;
+  }
+}


### PR DESCRIPTION
- [x] Added Native iOS GMImagePicker v 0.0.2 third party pod library for image picker support below iOS 14 to the Runner project
- [x] Created PlatformChannel in example project for using old iOS version picker
- [x] Model class for image picker path response
- [x] Platform helper class to consume the native service channels
- [x] Added permission in info.plist iOS
- [x] Created Native channel method for checking iOS version below 14